### PR TITLE
Improves closing/error handling workflows.

### DIFF
--- a/engine/jobpoolengine/engine_test.go
+++ b/engine/jobpoolengine/engine_test.go
@@ -2,11 +2,14 @@ package jobpoolengine_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/arquivei/goduck/engine/jobpoolengine"
 	"github.com/arquivei/goduck/impl/implprocessor"
 	"github.com/arquivei/goduck/impl/implqueue"
+
+	"github.com/arquivei/foundationkit/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,8 +30,9 @@ func TestJobPoolCancel(t *testing.T) {
 	nWorkers := 5
 	wait := make(chan struct{})
 	done := make(chan struct{})
-	processor := implprocessor.New(func() {
+	processor := implprocessor.New(func() error {
 		<-wait
+		return nil
 	})
 	queue := implqueue.NewDefaultQueue(100)
 	defer queue.Close()
@@ -42,4 +46,30 @@ func TestJobPoolCancel(t *testing.T) {
 	cancelFn()
 	close(wait)
 	<-done
+}
+
+// TestStreamFatal asserts that the engine stops when the processor returns a
+// fatal error
+func TestStreamFatal(t *testing.T) {
+	nWorkers := 5
+	failAfter := 10
+	expectedErr := errors.E("my error", errors.SeverityFatal)
+
+	count := 0
+	countMtx := &sync.Mutex{}
+	processor := implprocessor.New(func() error {
+		countMtx.Lock()
+		defer countMtx.Unlock()
+		count++
+		if count >= failAfter {
+			return expectedErr
+		}
+		return nil
+	})
+	queue := implqueue.NewDefaultQueue(100)
+	defer queue.Close()
+
+	w := jobpoolengine.New(queue, processor, nWorkers)
+	err := w.Run(context.Background())
+	assert.Equal(t, expectedErr, err)
 }

--- a/engine/streamengine/engine_test.go
+++ b/engine/streamengine/engine_test.go
@@ -2,12 +2,15 @@ package streamengine_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/arquivei/goduck"
 	"github.com/arquivei/goduck/engine/streamengine"
 	"github.com/arquivei/goduck/impl/implprocessor"
 	"github.com/arquivei/goduck/impl/implstream"
+
+	"github.com/arquivei/foundationkit/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +28,8 @@ func TestStream(t *testing.T) {
 	}()
 
 	w := streamengine.New(processor, streams)
-	w.Run(context.Background())
+	err := w.Run(context.Background())
+	assert.NoError(t, err)
 
 	assert.Equal(t, 500, len(processor.Success))
 
@@ -50,10 +54,43 @@ func TestStreamCancel(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	w := streamengine.New(processor, streams)
 	go func() {
-		w.Run(ctx)
+		err := w.Run(ctx)
+		assert.NoError(t, err)
 		close(done)
 	}()
 	cancelFn()
 	close(wait)
 	<-done
+}
+
+// TestStreamFatal asserts that the engine stops when the processor returns a
+// fatal error
+func TestStreamFatal(t *testing.T) {
+	nWorkers := 5
+	failAfter := 10
+	expectedErr := errors.E("my error", errors.SeverityFatal)
+
+	count := 0
+	countMtx := &sync.Mutex{}
+	processor := implprocessor.New(func() error {
+		countMtx.Lock()
+		defer countMtx.Unlock()
+		count++
+		if count >= failAfter {
+			return expectedErr
+		}
+		return nil
+	})
+	streams := make([]goduck.Stream, nWorkers)
+	for i := 0; i < nWorkers; i++ {
+		streams[i] = implstream.NewDefaultStream(i, 100)
+	}
+	defer func() {
+		for _, stream := range streams {
+			stream.Close()
+		}
+	}()
+	w := streamengine.New(processor, streams)
+	err := w.Run(context.Background())
+	assert.Equal(t, expectedErr, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/pubsub v1.2.0
 	github.com/Shopify/sarama v1.26.1
 	github.com/arquivei/foundationkit v0.0.0-20200302211010-306c93c13d0d
+	github.com/imkira/go-observer v1.0.3
 	github.com/rs/zerolog v1.14.3
 	github.com/segmentio/kafka-go v0.3.5
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imkira/go-observer v1.0.3 h1:l45TYAEeAB4L2xF6PR2gRLn2NE5tYhudh33MLmC7B80=
+github.com/imkira/go-observer v1.0.3/go.mod h1:zLzElv2cGTHufQG17IEILJMPDg32TD85fFgKyFv00wU=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/impl/implprocessor/mock.go
+++ b/impl/implprocessor/mock.go
@@ -10,10 +10,10 @@ type MockProcessor struct {
 	mtx           *sync.Mutex
 	jobsProcessed int
 	Success       map[string]bool
-	CustomFn      func()
+	CustomFn      func() error
 }
 
-func New(customFn func()) *MockProcessor {
+func New(customFn func() error) *MockProcessor {
 	return &MockProcessor{
 		mtx:           &sync.Mutex{},
 		jobsProcessed: 0,
@@ -33,7 +33,7 @@ func (m *MockProcessor) Process(ctx context.Context, message []byte) error {
 	}
 	m.Success[strMessage] = true
 	if m.CustomFn != nil {
-		m.CustomFn()
+		return m.CustomFn()
 	}
 	return nil
 }
@@ -53,7 +53,7 @@ func (m *MockProcessor) BatchProcess(ctx context.Context, messages [][]byte) err
 	}
 
 	if m.CustomFn != nil {
-		m.CustomFn()
+		return m.CustomFn()
 	}
 	return nil
 }

--- a/impl/implstream/kafkasarama/kafka.go
+++ b/impl/implstream/kafkasarama/kafka.go
@@ -63,7 +63,6 @@ func (c *goduckStream) run() {
 		err := c.consumer.Consume(ctx, c.topics, c.handler)
 		if err != nil {
 			log.Error().Err(err).Msg("Error consuming messages")
-			break
 		}
 	}
 	c.Close()


### PR DESCRIPTION
Allows the engine to handle fatal errors.
    
    When the processor returns an error with SeverityFatal, the engine shouldn't
    retry processing that message.
    
    This is specially important in stream processing, because timeouts could be
    intepreted by the broker as worker failures, which could cause inconsistent
    states.

 Fixes cleanup workflow.
    
    When a rebalance is triggered, the didn't wait for the inflight messages to be
    successfully processed, which meant the messages were reprocessed by a
    different worker, leading to inconsistencies
