### PR TITLE
Refactors impl/ folder

### DIFF
--- a/engine/batchstreamengine/engine_test.go
+++ b/engine/batchstreamengine/engine_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/arquivei/goduck"
 	"github.com/arquivei/goduck/engine/batchstreamengine"
 	"github.com/arquivei/goduck/impl/implprocessor"
-	"github.com/arquivei/goduck/impl/implstream"
+	"github.com/arquivei/goduck/impl/implstream/mockstream"
 
 	"github.com/arquivei/foundationkit/errors"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +20,7 @@ func TestStream(t *testing.T) {
 	processor := implprocessor.New(nil)
 	streams := make([]goduck.Stream, nWorkers)
 	for i := 0; i < nWorkers; i++ {
-		streams[i] = implstream.NewDefaultStream(i, 100)
+		streams[i] = mockstream.NewDefaultStream(i, 100)
 	}
 	defer func() {
 		for _, stream := range streams {
@@ -40,7 +40,7 @@ func TestStreamNoTimeout(t *testing.T) {
 	processor := implprocessor.New(nil)
 	streams := make([]goduck.Stream, nWorkers)
 	for i := 0; i < nWorkers; i++ {
-		streams[i] = implstream.NewDefaultStream(i, 100)
+		streams[i] = mockstream.NewDefaultStream(i, 100)
 	}
 	defer func() {
 		for _, stream := range streams {
@@ -66,7 +66,7 @@ func TestStreamCancel(t *testing.T) {
 	})
 	streams := make([]goduck.Stream, nWorkers)
 	for i := 0; i < nWorkers; i++ {
-		streams[i] = implstream.NewDefaultStream(i, 100)
+		streams[i] = mockstream.NewDefaultStream(i, 100)
 	}
 	defer func() {
 		for _, stream := range streams {
@@ -105,7 +105,7 @@ func TestStreamFatal(t *testing.T) {
 	})
 	streams := make([]goduck.Stream, nWorkers)
 	for i := 0; i < nWorkers; i++ {
-		streams[i] = implstream.NewDefaultStream(i, 100)
+		streams[i] = mockstream.NewDefaultStream(i, 100)
 	}
 	defer func() {
 		for _, stream := range streams {

--- a/engine/jobpoolengine/engine_test.go
+++ b/engine/jobpoolengine/engine_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/arquivei/goduck/engine/jobpoolengine"
 	"github.com/arquivei/goduck/impl/implprocessor"
-	"github.com/arquivei/goduck/impl/implqueue"
+	"github.com/arquivei/goduck/impl/implqueue/mockqueue"
 
 	"github.com/arquivei/foundationkit/errors"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +16,7 @@ import (
 func TestJobPool(t *testing.T) {
 	nWorkers := 5
 	processor := implprocessor.New(nil)
-	queue := implqueue.NewDefaultQueue(100)
+	queue := mockqueue.NewDefaultQueue(100)
 	defer queue.Close()
 	w := jobpoolengine.New(queue, processor, nWorkers)
 	w.Run(context.Background())
@@ -34,7 +34,7 @@ func TestJobPoolCancel(t *testing.T) {
 		<-wait
 		return nil
 	})
-	queue := implqueue.NewDefaultQueue(100)
+	queue := mockqueue.NewDefaultQueue(100)
 	defer queue.Close()
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -66,7 +66,7 @@ func TestStreamFatal(t *testing.T) {
 		}
 		return nil
 	})
-	queue := implqueue.NewDefaultQueue(100)
+	queue := mockqueue.NewDefaultQueue(100)
 	defer queue.Close()
 
 	w := jobpoolengine.New(queue, processor, nWorkers)

--- a/engine/streamengine/engine_test.go
+++ b/engine/streamengine/engine_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/arquivei/goduck"
 	"github.com/arquivei/goduck/engine/streamengine"
 	"github.com/arquivei/goduck/impl/implprocessor"
-	"github.com/arquivei/goduck/impl/implstream"
+	"github.com/arquivei/goduck/impl/implstream/mockstream"
 
 	"github.com/arquivei/foundationkit/errors"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +19,7 @@ func TestStream(t *testing.T) {
 	processor := implprocessor.New(nil)
 	streams := make([]goduck.Stream, nWorkers)
 	for i := 0; i < nWorkers; i++ {
-		streams[i] = implstream.NewDefaultStream(i, 100)
+		streams[i] = mockstream.NewDefaultStream(i, 100)
 	}
 	defer func() {
 		for _, stream := range streams {
@@ -43,7 +43,7 @@ func TestStreamCancel(t *testing.T) {
 	processor := implprocessor.New(nil)
 	streams := make([]goduck.Stream, nWorkers)
 	for i := 0; i < nWorkers; i++ {
-		streams[i] = implstream.NewDefaultStream(i, 100)
+		streams[i] = mockstream.NewDefaultStream(i, 100)
 	}
 	defer func() {
 		for _, stream := range streams {
@@ -83,7 +83,7 @@ func TestStreamFatal(t *testing.T) {
 	})
 	streams := make([]goduck.Stream, nWorkers)
 	for i := 0; i < nWorkers; i++ {
-		streams[i] = implstream.NewDefaultStream(i, 100)
+		streams[i] = mockstream.NewDefaultStream(i, 100)
 	}
 	defer func() {
 		for _, stream := range streams {

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/arquivei/goduck"
 	"github.com/arquivei/goduck/engine/jobpoolengine"
 	"github.com/arquivei/goduck/engine/streamengine"
-	"github.com/arquivei/goduck/impl/implqueue"
-	"github.com/arquivei/goduck/impl/implstream"
+	"github.com/arquivei/goduck/impl/implqueue/mockqueue"
+	"github.com/arquivei/goduck/impl/implstream/mockstream"
 )
 
 func TestSimpleQueue(t *testing.T) {
 	processor := NewSimpleProcessor().(*simpleProcessor)
 	dataset := newSimpleTestDataset()
 
-	queue := implqueue.NewMock(dataset.makeBytes())
+	queue := mockqueue.New(dataset.makeBytes())
 	engine := jobpoolengine.New(queue, processor, 2)
 	engine.Run(context.Background())
 	dataset.validate(processor.consumed)
@@ -25,7 +25,7 @@ func TestSimpleStream(t *testing.T) {
 	processor := NewSimpleProcessor().(*simpleProcessor)
 	dataset := newSimpleTestDataset()
 
-	stream := implstream.NewMock(dataset.makeBytes())
+	stream := mockstream.New(dataset.makeBytes())
 	engine := streamengine.New(processor, []goduck.Stream{stream})
 	engine.Run(context.Background())
 	dataset.validate(processor.consumed)

--- a/impl/implqueue/mock.go
+++ b/impl/implqueue/mock.go
@@ -1,104 +1,19 @@
 package implqueue
 
 import (
-	"context"
-	"io"
-	"strconv"
-	"sync"
-
-	"github.com/arquivei/foundationkit/errors"
-	"github.com/arquivei/goduck"
+	"github.com/arquivei/goduck/impl/implqueue/mockqueue"
 )
 
-type MockQueue struct {
-	items         []goduck.RawMessage
-	consumedItems []bool
-	currentIdx    int
-	mtx           *sync.Mutex
+// NewMock creates a new queue mock.
+//
+// Deprecated: use mockqueue.New instead
+func NewMock(items [][]byte) *mockqueue.MockQueue {
+	return mockqueue.New(items)
 }
 
-func NewMock(items [][]byte) *MockQueue {
-	consumedItems := make([]bool, len(items))
-	messages := make([]goduck.RawMessage, len(items))
-
-	for i := 0; i < len(items); i++ {
-		consumedItems[i] = false
-		messages[i] = &mockRawMessage{
-			data: items[i],
-			idx:  i,
-		}
-	}
-	return &MockQueue{
-		items:         messages,
-		consumedItems: consumedItems,
-		currentIdx:    0,
-		mtx:           &sync.Mutex{},
-	}
-}
-
-func NewDefaultQueue(nElems int) *MockQueue {
-	messages := make([][]byte, nElems)
-
-	for i := 0; i < nElems; i++ {
-		messages[i] = []byte(strconv.Itoa(i))
-	}
-	return NewMock(messages)
-}
-
-func (m *MockQueue) Next(ctx context.Context) (goduck.RawMessage, error) {
-	const op = errors.Op("MockQueue.Pool")
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	nElems := len(m.consumedItems)
-
-	for tries := 0; tries < nElems; tries++ {
-		if !m.consumedItems[m.currentIdx] {
-			msg := m.items[m.currentIdx]
-			m.currentIdx = (m.currentIdx + 1) % nElems
-			return msg, nil
-		}
-		m.currentIdx = (m.currentIdx + 1) % nElems
-	}
-
-	return nil, io.EOF
-}
-
-func (m MockQueue) Done(ctx context.Context, msg goduck.RawMessage) error {
-	const op = errors.Op("MockQueue.Done")
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	rawMsg, ok := msg.(*mockRawMessage)
-	if !ok {
-		return errors.E(op, "type cast error")
-	}
-	m.consumedItems[rawMsg.idx] = true
-	return nil
-}
-func (m MockQueue) Failed(ctx context.Context, msg goduck.RawMessage) error {
-	const op = errors.Op("MockQueue.Failed")
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	rawMsg, ok := msg.(*mockRawMessage)
-	if !ok {
-		return errors.E(op, "type cast error")
-	}
-	if m.consumedItems[rawMsg.idx] {
-		return errors.E(op, "message status was 'Done'")
-	}
-	return nil
-}
-
-func (m MockQueue) Close() error {
-	return nil
-}
-
-// IsEmpty tests if all elements in the queue are consumed
-func (m MockQueue) IsEmpty() bool {
-	for i := 0; i < len(m.consumedItems); i++ {
-		if !m.consumedItems[i] {
-			return false
-		}
-	}
-	return true
+// NewDefaultQueue creates a new queue mock with default items.
+//
+// Deprecated: use mockqueue.NewDefaultQueue instead
+func NewDefaultQueue(nElems int) *mockqueue.MockQueue {
+	return mockqueue.NewDefaultQueue(nElems)
 }

--- a/impl/implqueue/mockqueue/entity_mockmessage.go
+++ b/impl/implqueue/mockqueue/entity_mockmessage.go
@@ -1,4 +1,4 @@
-package implstream
+package mockqueue
 
 type mockRawMessage struct {
 	data []byte

--- a/impl/implqueue/mockqueue/mock.go
+++ b/impl/implqueue/mockqueue/mock.go
@@ -1,0 +1,106 @@
+package mockqueue
+
+import (
+	"context"
+	"io"
+	"strconv"
+	"sync"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/goduck"
+)
+
+type MockQueue struct {
+	items         []goduck.RawMessage
+	consumedItems []bool
+	currentIdx    int
+	mtx           *sync.Mutex
+}
+
+// New creates a new queue mock.
+func New(items [][]byte) *MockQueue {
+	consumedItems := make([]bool, len(items))
+	messages := make([]goduck.RawMessage, len(items))
+
+	for i := 0; i < len(items); i++ {
+		consumedItems[i] = false
+		messages[i] = &mockRawMessage{
+			data: items[i],
+			idx:  i,
+		}
+	}
+	return &MockQueue{
+		items:         messages,
+		consumedItems: consumedItems,
+		currentIdx:    0,
+		mtx:           &sync.Mutex{},
+	}
+}
+
+// NewDefaultQueue creates a new queue mock with default items.
+func NewDefaultQueue(nElems int) *MockQueue {
+	messages := make([][]byte, nElems)
+
+	for i := 0; i < nElems; i++ {
+		messages[i] = []byte(strconv.Itoa(i))
+	}
+	return NewMock(messages)
+}
+
+func (m *MockQueue) Next(ctx context.Context) (goduck.RawMessage, error) {
+	const op = errors.Op("MockQueue.Pool")
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	nElems := len(m.consumedItems)
+
+	for tries := 0; tries < nElems; tries++ {
+		if !m.consumedItems[m.currentIdx] {
+			msg := m.items[m.currentIdx]
+			m.currentIdx = (m.currentIdx + 1) % nElems
+			return msg, nil
+		}
+		m.currentIdx = (m.currentIdx + 1) % nElems
+	}
+
+	return nil, io.EOF
+}
+
+func (m MockQueue) Done(ctx context.Context, msg goduck.RawMessage) error {
+	const op = errors.Op("MockQueue.Done")
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	rawMsg, ok := msg.(*mockRawMessage)
+	if !ok {
+		return errors.E(op, "type cast error")
+	}
+	m.consumedItems[rawMsg.idx] = true
+	return nil
+}
+func (m MockQueue) Failed(ctx context.Context, msg goduck.RawMessage) error {
+	const op = errors.Op("MockQueue.Failed")
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	rawMsg, ok := msg.(*mockRawMessage)
+	if !ok {
+		return errors.E(op, "type cast error")
+	}
+	if m.consumedItems[rawMsg.idx] {
+		return errors.E(op, "message status was 'Done'")
+	}
+	return nil
+}
+
+func (m MockQueue) Close() error {
+	return nil
+}
+
+// IsEmpty tests if all elements in the queue are consumed
+func (m MockQueue) IsEmpty() bool {
+	for i := 0; i < len(m.consumedItems); i++ {
+		if !m.consumedItems[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/impl/implqueue/mockqueue/mock_test.go
+++ b/impl/implqueue/mockqueue/mock_test.go
@@ -1,4 +1,4 @@
-package implqueue
+package mockqueue
 
 import (
 	"context"

--- a/impl/implqueue/pubsub.go
+++ b/impl/implqueue/pubsub.go
@@ -1,13 +1,11 @@
 package implqueue
 
 import (
-	"context"
-	"io"
 	"sync"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/arquivei/foundationkit/errors"
 	"github.com/arquivei/goduck"
+	"github.com/arquivei/goduck/impl/implqueue/pubsubqueue"
 )
 
 // PubsubConfigs contains the configs for pubsub connection
@@ -25,95 +23,12 @@ type pubsubConsumer struct {
 	cancelFn     func()
 }
 
+// NewPubsubQueue creates a new pubsub queue
+//
+// Deprecated: use pubsubqueue.New instead
 func NewPubsubQueue(config PubsubConfigs) (goduck.MessagePool, error) {
-	const op = errors.Op("implpubsub.NewPubsubQueue")
-	client, err := pubsub.NewClient(context.Background(), config.ProjectID)
-	if err != nil {
-		return nil, errors.E(op, err)
-	}
-	subscription := client.Subscription(config.Subscription)
-	consumer := &pubsubConsumer{
-		client:       client,
-		subscription: subscription,
-		nextMessage:  make(chan *pubsub.Message),
-		errChannel:   make(chan error),
-		closeOnce:    &sync.Once{},
-	}
-	go consumer.start()
-	return consumer, nil
-}
-
-func (p *pubsubConsumer) start() {
-	const op = errors.Op("pubsubConsumer.start")
-	ctx, cancelFn := context.WithCancel(context.Background())
-	p.cancelFn = cancelFn
-	err := p.subscription.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
-		select {
-		case p.nextMessage <- msg:
-		case <-ctx.Done():
-		}
+	return pubsubqueue.New(pubsubqueue.PubsubConfigs{
+		ProjectID:    config.ProjectID,
+		Subscription: config.Subscription,
 	})
-	if err != nil {
-		p.errChannel <- errors.E(op, err)
-	}
-	p.Close()
-}
-
-func (p *pubsubConsumer) Next(ctx context.Context) (goduck.RawMessage, error) {
-	const op = errors.Op("pubsubConsumer.Poll")
-	select {
-	case err, ok := <-p.errChannel:
-		if !ok {
-			return nil, io.EOF
-		}
-		return nil, errors.E(op, err)
-	case msg, ok := <-p.nextMessage:
-		if !ok {
-			return nil, io.EOF
-		}
-		rawMsg := &rawMessage{
-			msg:      msg,
-			metadata: getMetadataFromMessage(msg),
-		}
-		return rawMsg, nil
-	case <-ctx.Done():
-		return nil, io.EOF
-	}
-}
-
-func (p pubsubConsumer) Done(ctx context.Context, msg goduck.RawMessage) error {
-	const op = errors.Op("pubsubConsumer.Done")
-	casted, ok := msg.(*rawMessage)
-	if !ok {
-		return errors.E(op, "invalid message type")
-	}
-	casted.msg.Ack()
-	return nil
-}
-
-func (p pubsubConsumer) Failed(ctx context.Context, msg goduck.RawMessage) error {
-	const op = errors.Op("pubsubConsumer.Failed")
-	casted, ok := msg.(*rawMessage)
-	if !ok {
-		return errors.E(op, "invalid message type")
-	}
-	casted.msg.Nack()
-	return nil
-}
-
-func (p *pubsubConsumer) Close() error {
-	p.closeOnce.Do(func() {
-		p.cancelFn()
-		close(p.nextMessage)
-		close(p.errChannel)
-	})
-	return nil
-}
-
-func getMetadataFromMessage(msg *pubsub.Message) map[string][]byte {
-	meta := map[string][]byte{}
-	for key, value := range msg.Attributes {
-		meta[key] = []byte(value)
-	}
-	return meta
 }

--- a/impl/implqueue/pubsubqueue/entity_message.go
+++ b/impl/implqueue/pubsubqueue/entity_message.go
@@ -1,4 +1,4 @@
-package implqueue
+package pubsubqueue
 
 import "cloud.google.com/go/pubsub"
 

--- a/impl/implqueue/pubsubqueue/pubsub.go
+++ b/impl/implqueue/pubsubqueue/pubsub.go
@@ -1,0 +1,120 @@
+package pubsubqueue
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/goduck"
+)
+
+// PubsubConfigs contains the configs for pubsub connection
+type PubsubConfigs struct {
+	ProjectID    string
+	Subscription string
+}
+
+type pubsubConsumer struct {
+	client       *pubsub.Client
+	subscription *pubsub.Subscription
+	nextMessage  chan *pubsub.Message
+	errChannel   chan error
+	closeOnce    *sync.Once
+	cancelFn     func()
+}
+
+// New creates a new pubsub queue
+func New(config PubsubConfigs) (goduck.MessagePool, error) {
+	const op = errors.Op("implpubsub.NewPubsubQueue")
+	client, err := pubsub.NewClient(context.Background(), config.ProjectID)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	subscription := client.Subscription(config.Subscription)
+	consumer := &pubsubConsumer{
+		client:       client,
+		subscription: subscription,
+		nextMessage:  make(chan *pubsub.Message),
+		errChannel:   make(chan error),
+		closeOnce:    &sync.Once{},
+	}
+	go consumer.start()
+	return consumer, nil
+}
+
+func (p *pubsubConsumer) start() {
+	const op = errors.Op("pubsubConsumer.start")
+	ctx, cancelFn := context.WithCancel(context.Background())
+	p.cancelFn = cancelFn
+	err := p.subscription.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+		select {
+		case p.nextMessage <- msg:
+		case <-ctx.Done():
+		}
+	})
+	if err != nil {
+		p.errChannel <- errors.E(op, err)
+	}
+	p.Close()
+}
+
+func (p *pubsubConsumer) Next(ctx context.Context) (goduck.RawMessage, error) {
+	const op = errors.Op("pubsubConsumer.Poll")
+	select {
+	case err, ok := <-p.errChannel:
+		if !ok {
+			return nil, io.EOF
+		}
+		return nil, errors.E(op, err)
+	case msg, ok := <-p.nextMessage:
+		if !ok {
+			return nil, io.EOF
+		}
+		rawMsg := &rawMessage{
+			msg:      msg,
+			metadata: getMetadataFromMessage(msg),
+		}
+		return rawMsg, nil
+	case <-ctx.Done():
+		return nil, io.EOF
+	}
+}
+
+func (p pubsubConsumer) Done(ctx context.Context, msg goduck.RawMessage) error {
+	const op = errors.Op("pubsubConsumer.Done")
+	casted, ok := msg.(*rawMessage)
+	if !ok {
+		return errors.E(op, "invalid message type")
+	}
+	casted.msg.Ack()
+	return nil
+}
+
+func (p pubsubConsumer) Failed(ctx context.Context, msg goduck.RawMessage) error {
+	const op = errors.Op("pubsubConsumer.Failed")
+	casted, ok := msg.(*rawMessage)
+	if !ok {
+		return errors.E(op, "invalid message type")
+	}
+	casted.msg.Nack()
+	return nil
+}
+
+func (p *pubsubConsumer) Close() error {
+	p.closeOnce.Do(func() {
+		p.cancelFn()
+		close(p.nextMessage)
+		close(p.errChannel)
+	})
+	return nil
+}
+
+func getMetadataFromMessage(msg *pubsub.Message) map[string][]byte {
+	meta := map[string][]byte{}
+	for key, value := range msg.Attributes {
+		meta[key] = []byte(value)
+	}
+	return meta
+}

--- a/impl/implstream/kafka.go
+++ b/impl/implstream/kafka.go
@@ -1,15 +1,12 @@
 package implstream
 
 import (
-	"context"
 	"time"
 
-	"github.com/arquivei/foundationkit/errors"
 	"github.com/arquivei/goduck"
+	"github.com/arquivei/goduck/impl/implstream/kafkasegmentio"
 
-	"github.com/segmentio/kafka-go"
 	kafkaGo "github.com/segmentio/kafka-go"
-	"github.com/segmentio/kafka-go/sasl/plain"
 )
 
 // KafkaConfigs contains the configs for kafka connection
@@ -25,75 +22,22 @@ type KafkaConfigs struct {
 	CommitInterval time.Duration
 }
 
-type kafkaConsumer struct {
-	reader             *kafkaGo.Reader
-	uncommitedMessages []kafkaGo.Message
-}
-
+// NewKafkaStream creates a new goduck.Stream from kafka, using segmentio library
+// Deprecated: use kafkasegmentio.New instead
 func NewKafkaStream(config KafkaConfigs) goduck.Stream {
-	reader := kafkaGo.NewReader(
-		kafkaGo.ReaderConfig{
-			GroupID:        config.GroupID,
-			Brokers:        config.Brokers,
-			Topic:          config.Topic,
-			CommitInterval: config.CommitInterval,
-			Dialer: &kafka.Dialer{
-				Timeout: 10 * time.Second,
-				SASLMechanism: plain.Mechanism{
-					Username: config.Username,
-					Password: config.Password,
-				},
-			},
-		},
-	)
-	return &kafkaConsumer{
-		reader: reader,
-	}
+	return kafkasegmentio.New(kafkasegmentio.Configs{
+		Brokers:        config.Brokers,
+		Topic:          config.Topic,
+		GroupID:        config.GroupID,
+		Username:       config.Username,
+		Password:       config.Password,
+		CommitInterval: config.CommitInterval,
+	})
 }
 
 // NewKafkaStreamWithCustomConfigs allows creating a kafka connection with all
 // configs from the SegmentIO library
+// Deprecated: use kafkasegmentio.NewWithCustomConfigs instead
 func NewKafkaStreamWithCustomConfigs(config kafkaGo.ReaderConfig) goduck.Stream {
-	reader := kafkaGo.NewReader(config)
-	return &kafkaConsumer{
-		reader: reader,
-	}
-}
-
-func (c *kafkaConsumer) Next(ctx context.Context) (goduck.RawMessage, error) {
-	const op = errors.Op("kafkaConsumer.Poll")
-	msg, err := c.reader.FetchMessage(ctx)
-	if err != nil {
-		return nil, errors.E(op, err)
-	}
-	c.uncommitedMessages = append(c.uncommitedMessages, msg)
-	result := rawMessage{
-		bytes:    msg.Value,
-		metadata: getMetadataFromMessage(msg),
-	}
-	return result, nil
-}
-func (c *kafkaConsumer) Done(ctx context.Context) error {
-	const op = errors.Op("kafkaConsumer.Done")
-	err := c.reader.CommitMessages(ctx, c.uncommitedMessages...)
-	if err != nil {
-		return errors.E(op, err)
-	}
-	c.uncommitedMessages = c.uncommitedMessages[:0]
-	return nil
-}
-
-func (c *kafkaConsumer) Close() error {
-	const op = errors.Op("kafkaConsumer.Close")
-	err := c.reader.Close()
-	return errors.E(op, err)
-}
-
-func getMetadataFromMessage(msg kafka.Message) map[string][]byte {
-	meta := map[string][]byte{}
-	for _, header := range msg.Headers {
-		meta[header.Key] = header.Value
-	}
-	meta[goduck.KeyMetadata] = msg.Key
-	return meta
+	return kafkasegmentio.NewWithCustomConfigs(config)
 }

--- a/impl/implstream/kafkasegmentio/entity_message.go
+++ b/impl/implstream/kafkasegmentio/entity_message.go
@@ -1,4 +1,4 @@
-package implstream
+package kafkasegmentio
 
 type rawMessage struct {
 	bytes    []byte

--- a/impl/implstream/kafkasegmentio/kafka.go
+++ b/impl/implstream/kafkasegmentio/kafka.go
@@ -1,0 +1,100 @@
+package kafkasegmentio
+
+import (
+	"context"
+	"time"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/goduck"
+
+	"github.com/segmentio/kafka-go"
+	kafkaGo "github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl/plain"
+)
+
+// Configs contains the configs for kafka connection
+type Configs struct {
+	Brokers  []string
+	Topic    string
+	GroupID  string
+	Username string
+	Password string
+
+	// SegmentIO configs
+
+	CommitInterval time.Duration
+}
+
+type kafkaConsumer struct {
+	reader             *kafkaGo.Reader
+	uncommitedMessages []kafkaGo.Message
+}
+
+// New creates a new goduck.Stream from kafka, using segmentio library
+func New(config Configs) goduck.Stream {
+	reader := kafkaGo.NewReader(
+		kafkaGo.ReaderConfig{
+			GroupID:        config.GroupID,
+			Brokers:        config.Brokers,
+			Topic:          config.Topic,
+			CommitInterval: config.CommitInterval,
+			Dialer: &kafka.Dialer{
+				Timeout: 10 * time.Second,
+				SASLMechanism: plain.Mechanism{
+					Username: config.Username,
+					Password: config.Password,
+				},
+			},
+		},
+	)
+	return &kafkaConsumer{
+		reader: reader,
+	}
+}
+
+// NewWithCustomConfigs allows creating a kafka connection with all
+// configs from the SegmentIO library
+func NewWithCustomConfigs(config kafkaGo.ReaderConfig) goduck.Stream {
+	reader := kafkaGo.NewReader(config)
+	return &kafkaConsumer{
+		reader: reader,
+	}
+}
+
+func (c *kafkaConsumer) Next(ctx context.Context) (goduck.RawMessage, error) {
+	const op = errors.Op("kafkaConsumer.Poll")
+	msg, err := c.reader.FetchMessage(ctx)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	c.uncommitedMessages = append(c.uncommitedMessages, msg)
+	result := rawMessage{
+		bytes:    msg.Value,
+		metadata: getMetadataFromMessage(msg),
+	}
+	return result, nil
+}
+func (c *kafkaConsumer) Done(ctx context.Context) error {
+	const op = errors.Op("kafkaConsumer.Done")
+	err := c.reader.CommitMessages(ctx, c.uncommitedMessages...)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	c.uncommitedMessages = c.uncommitedMessages[:0]
+	return nil
+}
+
+func (c *kafkaConsumer) Close() error {
+	const op = errors.Op("kafkaConsumer.Close")
+	err := c.reader.Close()
+	return errors.E(op, err)
+}
+
+func getMetadataFromMessage(msg kafka.Message) map[string][]byte {
+	meta := map[string][]byte{}
+	for _, header := range msg.Headers {
+		meta[header.Key] = header.Value
+	}
+	meta[goduck.KeyMetadata] = msg.Key
+	return meta
+}

--- a/impl/implstream/mock.go
+++ b/impl/implstream/mock.go
@@ -1,76 +1,17 @@
 package implstream
 
-import (
-	"context"
-	"io"
-	"strconv"
-	"sync"
+import "github.com/arquivei/goduck/impl/implstream/mockstream"
 
-	"github.com/arquivei/foundationkit/errors"
-	"github.com/arquivei/goduck"
-)
-
-type MockStream struct {
-	items         []goduck.RawMessage
-	nElems        int
-	offset        int
-	sessionOffset int
-	mtx           *sync.Mutex
+// NewMock creates a new stream mock
+//
+// Deprecated: use mockstream.New instead
+func NewMock(items [][]byte) *mockstream.MockStream {
+	return mockstream.New(items)
 }
 
-func NewMock(items [][]byte) *MockStream {
-	nElems := len(items)
-	messages := make([]goduck.RawMessage, len(items))
-
-	for i := 0; i < len(items); i++ {
-		messages[i] = &mockRawMessage{
-			data: items[i],
-			idx:  i,
-		}
-	}
-	return &MockStream{
-		items:         messages,
-		nElems:        nElems,
-		offset:        0,
-		sessionOffset: 0,
-		mtx:           &sync.Mutex{},
-	}
-}
-func NewDefaultStream(partition int, nElems int) *MockStream {
-	messages := make([][]byte, nElems)
-	prefix := strconv.Itoa(partition) + ","
-	for i := 0; i < nElems; i++ {
-		messages[i] = []byte(prefix + strconv.Itoa(i))
-	}
-	return NewMock(messages)
-}
-
-func (m *MockStream) Next(ctx context.Context) (goduck.RawMessage, error) {
-	const op = errors.Op("MockStream.Pool")
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-
-	if m.sessionOffset == m.nElems {
-		return nil, io.EOF
-	}
-	msg := m.items[m.sessionOffset]
-	m.sessionOffset++
-	return msg, nil
-}
-
-func (m *MockStream) Done(ctx context.Context) error {
-	const op = errors.Op("MockStream.Done")
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	m.offset = m.sessionOffset
-	return nil
-}
-
-func (m MockStream) Close() error {
-	return nil
-}
-
-// IsEmpty tests if all elements in the queue are consumed
-func (m MockStream) IsEmpty() bool {
-	return m.nElems == m.offset
+// NewDefaultStream creates a new stream mock with default elements
+//
+// Deprecated: use mockstream.NewDefaultStream instead
+func NewDefaultStream(partition int, nElems int) *mockstream.MockStream {
+	return mockstream.NewDefaultStream(partition, nElems)
 }

--- a/impl/implstream/mockstream/entity_mockmessage.go
+++ b/impl/implstream/mockstream/entity_mockmessage.go
@@ -1,4 +1,4 @@
-package implqueue
+package mockstream
 
 type mockRawMessage struct {
 	data []byte

--- a/impl/implstream/mockstream/mock.go
+++ b/impl/implstream/mockstream/mock.go
@@ -1,0 +1,76 @@
+package mockstream
+
+import (
+	"context"
+	"io"
+	"strconv"
+	"sync"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/goduck"
+)
+
+type MockStream struct {
+	items         []goduck.RawMessage
+	nElems        int
+	offset        int
+	sessionOffset int
+	mtx           *sync.Mutex
+}
+
+func New(items [][]byte) *MockStream {
+	nElems := len(items)
+	messages := make([]goduck.RawMessage, len(items))
+
+	for i := 0; i < len(items); i++ {
+		messages[i] = &mockRawMessage{
+			data: items[i],
+			idx:  i,
+		}
+	}
+	return &MockStream{
+		items:         messages,
+		nElems:        nElems,
+		offset:        0,
+		sessionOffset: 0,
+		mtx:           &sync.Mutex{},
+	}
+}
+func NewDefaultStream(partition int, nElems int) *MockStream {
+	messages := make([][]byte, nElems)
+	prefix := strconv.Itoa(partition) + ","
+	for i := 0; i < nElems; i++ {
+		messages[i] = []byte(prefix + strconv.Itoa(i))
+	}
+	return New(messages)
+}
+
+func (m *MockStream) Next(ctx context.Context) (goduck.RawMessage, error) {
+	const op = errors.Op("MockStream.Pool")
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if m.sessionOffset == m.nElems {
+		return nil, io.EOF
+	}
+	msg := m.items[m.sessionOffset]
+	m.sessionOffset++
+	return msg, nil
+}
+
+func (m *MockStream) Done(ctx context.Context) error {
+	const op = errors.Op("MockStream.Done")
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.offset = m.sessionOffset
+	return nil
+}
+
+func (m MockStream) Close() error {
+	return nil
+}
+
+// IsEmpty tests if all elements in the queue are consumed
+func (m MockStream) IsEmpty() bool {
+	return m.nElems == m.offset
+}

--- a/impl/implstream/mockstream/mock_test.go
+++ b/impl/implstream/mockstream/mock_test.go
@@ -1,4 +1,4 @@
-package implstream
+package mockstream
 
 import (
 	"context"


### PR DESCRIPTION
The impl/ folder was using an old pattern, where every implementation would
fall into the same package. The major problem with this approach is that it
forces the clients to import way more dependencies than it is really needed.

This commit refactors the implementations into specific folders, while also
mantaining the deprecated versions for compatibility.

Fixes #11