### PR TITLE
Adds a New stream func that does not panic

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -901,7 +901,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=

--- a/go.sum
+++ b/go.sum
@@ -901,6 +901,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=

--- a/impl/implstream/kafkaconfluent/stream.go
+++ b/impl/implstream/kafkaconfluent/stream.go
@@ -7,11 +7,22 @@ import (
 	"sync"
 	"time"
 
-	"github.com/arquivei/foundationkit/errors"
 	"github.com/arquivei/goduck"
-	"github.com/rs/zerolog/log"
 
+	"github.com/arquivei/foundationkit/errors"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	//ErrEmptyBroker is returned when the the broker is missing from the Config struct
+	ErrEmptyBroker = errors.New("invalid config: empty broker")
+	//ErrEmptyTopic is returned when the the Topic is missing from the Config struct
+	ErrEmptyTopic = errors.New("invalid config: empty topic")
+	//ErrEmptyUsername is returned when the the Username is missing from the Config struct
+	ErrEmptyUsername = errors.New("invalid config: empty username")
+	//ErrEmptyPassword is returned when the the Password is missing from the Config struct
+	ErrEmptyPassword = errors.New("invalid config: empty password")
 )
 
 // Config contains the configuration necessary to build the
@@ -52,19 +63,23 @@ type goduckStream struct {
 	disableCommit bool
 }
 
-// MustNew creates a confluent-kafka-go goduck.Stream with default configs
-func MustNew(config Config) goduck.Stream {
+// New creates a confluent-kafka-go goduck.Stream with default configs
+func New(config Config) (goduck.Stream, error) {
+	if len(config.Topics) == 0 {
+		return nil, ErrEmptyTopic
+	}
+
 	if config.RDKafkaConfig == nil {
-		if config.Brokers == nil || len(config.Brokers) == 0 {
-			panic("Empty broker")
+		if len(config.Brokers) == 0 {
+			return nil, ErrEmptyBroker
 		}
 
 		if config.Username == "" {
-			panic("Empty username")
+			return nil, ErrEmptyUsername
 		}
 
 		if config.Password == "" {
-			panic("Empty password")
+			return nil, ErrEmptyPassword
 		}
 
 		config.RDKafkaConfig = &kafka.ConfigMap{
@@ -79,24 +94,30 @@ func MustNew(config Config) goduck.Stream {
 		}
 	}
 
-	if config.Topics == nil || len(config.Topics) == 0 {
-		panic("Empty broker")
-	}
 	if config.PoolTimeout == 0 {
 		config.PoolTimeout = time.Second
 	}
-	return mustCreateStream(config)
+	return createStream(config)
 }
 
-func mustCreateStream(config Config) goduck.Stream {
-	c, err := kafka.NewConsumer(config.RDKafkaConfig)
+// MustNew creates a confluent-kafkam with default configs
+func MustNew(config Config) goduck.Stream {
+	s, err := New(config)
 	if err != nil {
 		panic(err)
+	}
+	return s
+}
+
+func createStream(config Config) (goduck.Stream, error) {
+	c, err := kafka.NewConsumer(config.RDKafkaConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	err = c.SubscribeTopics(config.Topics, nil)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	done := make(chan struct{})
 	stream := &goduckStream{
@@ -113,7 +134,7 @@ func mustCreateStream(config Config) goduck.Stream {
 	stream.waitGroup.Add(1)
 	go stream.backgroundPoll()
 
-	return stream
+	return stream, nil
 }
 
 func (c *goduckStream) Next(ctx context.Context) (goduck.RawMessage, error) {

--- a/impl/implstream/kafkaconfluent/stream.go
+++ b/impl/implstream/kafkaconfluent/stream.go
@@ -16,13 +16,13 @@ import (
 
 var (
 	//ErrEmptyBroker is returned when the the broker is missing from the Config struct
-	ErrEmptyBroker = errors.New("invalid config: empty broker")
+	ErrEmptyBroker = errors.New("bad config: empty broker")
 	//ErrEmptyTopic is returned when the the Topic is missing from the Config struct
-	ErrEmptyTopic = errors.New("invalid config: empty topic")
+	ErrEmptyTopic = errors.New("bad config: empty topic")
 	//ErrEmptyUsername is returned when the the Username is missing from the Config struct
-	ErrEmptyUsername = errors.New("invalid config: empty username")
+	ErrEmptyUsername = errors.New("bad config: empty username")
 	//ErrEmptyPassword is returned when the the Password is missing from the Config struct
-	ErrEmptyPassword = errors.New("invalid config: empty password")
+	ErrEmptyPassword = errors.New("bad config: empty password")
 )
 
 // Config contains the configuration necessary to build the


### PR DESCRIPTION
Previously existed only the MustNew function for creating streams. This
function panics in case of errors. This can be a problem sometimes.

This commit adds a new function New that returns an error instead of
panic and refactors MustNew to call New and panic in case of an error.

Also fix the error when topic was empty. It was reporting empty broker
instead of empty topic.