### PR TITLE
Adds ElasticSink Option to ignore some errors

### DIFF
--- a/pipeline/elasticsink/options.go
+++ b/pipeline/elasticsink/options.go
@@ -1,0 +1,9 @@
+package elasticsink
+
+type Option func(*elasticSink)
+
+func WithIgnoreIndexNotFoundOnDelete() Option {
+	return func(es *elasticSink) {
+		es.deleteOptions.IgnoreIndexNotFoundError = true
+	}
+}


### PR DESCRIPTION
If the ElasticSink receives an DeleteMessage but the index does not
exist, it returns an error. This is a problem in some cases that we
would like to handle delete of an non-existing document as a success.

Adds a new option on the ElasticSink for ignoring errors for
non-existing indexes during delete operations. The error handling was
made come complete. Now all non-ignorable errors are extracted from the
bulk and returned as errors.KV.

Also the error now contains more information of the error and the log
was removed since the application now can log the complete error.