### PR TITLE
Fixes pipeline.kafkasink panic after produce errors

### DIFF
--- a/pipeline/kafkasink/sink.go
+++ b/pipeline/kafkasink/sink.go
@@ -76,8 +76,8 @@ func (p *kafkaPusher) Store(ctx context.Context, messages ...pipeline.SinkMessag
 		sdkMessages[i] = sdkMsg
 	}
 
-	deliveryChan := make(chan kafka.Event)
-	defer close(deliveryChan)
+	deliveryChan := make(chan kafka.Event, len(sdkMessages))
+
 	for _, msg := range sdkMessages {
 		err := p.producer.Produce(msg, deliveryChan)
 		if err != nil {


### PR DESCRIPTION
When one of the messages in the batch fails to be produced to kafka, the function is returned end the delivery chan is closed. But there are still in-flight messages that have to be delivered to that channel. This causes a panic because the lib tries to write to a closed channel.

 - Stops closing the channel at the end of the function
 - Adds a buffer to the channel to avoid memory leaks in the library trying to write do a channel that nobody is listening