### PR TITLE
[ FEAT | FIX ] Corrige falha na escrita de metadata no sink de GCS

### DIFF
--- a/pipeline/gcssink/adapter_gcsclient.go
+++ b/pipeline/gcssink/adapter_gcsclient.go
@@ -46,6 +46,8 @@ func (g gcsClientGateway) GetWriter(
 func (g gcsClientGateway) Write(writer *storage.Writer, message SinkMessage) error {
 	const op = errors.Op("gcssink.gcsClientGateway.Write")
 
+	writer.Metadata = message.Metadata
+
 	if _, err := writer.Write(message.Data); err != nil {
 		return errors.E(op, err, CodeFailedToWriteAtBucket, errors.KV("bucket", message.Bucket), errors.KV("path", message.StoragePath))
 	}


### PR DESCRIPTION
Problema:

O sink de gcs não estava escrevendo os dados de metadata.

Solução:

Implementa a escrita de metadata no sink de GCS

Observações:

Foi implementado a função MakeGcsRetrierOptions que retorna []storage.RetrierOptions para facilitar a implementação do retrierOption no gcsParallelWriter