### PR TITLE
Adiciona RunOnceEngine

### DIFF
--- a/engine/runoncenegine/engine.go
+++ b/engine/runoncenegine/engine.go
@@ -1,0 +1,114 @@
+package runoncenegine
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/arquivei/goduck"
+	"github.com/arquivei/goduck/gokithelper"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/go-kit/kit/endpoint"
+)
+
+// RunOnceEngine is an engine that processes a batch of messages only once and
+// then shuts down
+type RunOnceEngine struct {
+	stream         goduck.Stream
+	maxBatchSize   int
+	maxTimeout     time.Duration
+	batchProcessor goduck.BatchProcessor
+
+	cancelFn       func()
+	processorError error
+}
+
+// NewFromEndpoint creates a BatchProcessor from a go-kit endpoint
+func NewFromEndpoint(
+	e endpoint.Endpoint,
+	decoder goduck.EndpointBatchDecoder,
+	maxBatchSize int,
+	maxTimeout time.Duration,
+	stream goduck.Stream,
+) *RunOnceEngine {
+	return New(
+		gokithelper.MustNewEndpointBatchProcessor(e, decoder),
+		maxBatchSize,
+		maxTimeout,
+		stream,
+	)
+}
+
+// New creates a new RunOnceEngine.
+func New(
+	processor goduck.BatchProcessor,
+	maxBatchSize int,
+	maxTimeout time.Duration,
+	stream goduck.Stream,
+) *RunOnceEngine {
+	engine := &RunOnceEngine{
+		stream:         stream,
+		batchProcessor: processor,
+		maxBatchSize:   maxBatchSize,
+		maxTimeout:     maxTimeout,
+		processorError: nil,
+	}
+	return engine
+}
+
+// Run processes the messages and then closes
+func (e *RunOnceEngine) Run(ctx context.Context) error {
+	e.pollMessages(ctx, e.stream)
+	return e.processorError
+}
+
+func (e *RunOnceEngine) pollMessages(ctx context.Context, stream goduck.Stream) {
+	msgs, _ := e.pollMessagesBatch(ctx, stream)
+
+	if len(msgs) > 0 {
+		e.handleMessages(ctx, stream, msgs)
+	}
+}
+
+func (e *RunOnceEngine) pollMessagesBatch(ctx context.Context, stream goduck.Stream) ([]goduck.RawMessage, error) {
+	msgs := []goduck.RawMessage{}
+	var cancelFn context.CancelFunc
+	if e.maxTimeout > 0 {
+		ctx, cancelFn = context.WithTimeout(ctx, e.maxTimeout)
+		defer cancelFn()
+	}
+
+	for ctx.Err() == nil && len(msgs) < e.maxBatchSize {
+		msg, err := stream.Next(ctx)
+		if err == io.EOF {
+			return msgs, err
+		}
+		if err != nil {
+			continue
+		}
+		msgs = append(msgs, msg)
+	}
+	return msgs, nil
+}
+
+func (e *RunOnceEngine) handleMessages(ctx context.Context, stream goduck.Stream, msgs []goduck.RawMessage) {
+	msgBytes := make([][]byte, len(msgs))
+	for i, msg := range msgs {
+		msgBytes[i] = msg.Bytes()
+	}
+
+	err := e.batchProcessor.BatchProcess(context.Background(), msgBytes)
+	if err != nil && errors.GetSeverity(err) == errors.SeverityFatal {
+		e.selfClose(err)
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	stream.Done(ctx)
+}
+
+func (e *RunOnceEngine) selfClose(err error) {
+	e.processorError = err
+}

--- a/engine/runoncenegine/engine_test.go
+++ b/engine/runoncenegine/engine_test.go
@@ -1,0 +1,88 @@
+package runoncenegine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arquivei/goduck/engine/runoncenegine"
+	"github.com/arquivei/goduck/impl/implprocessor"
+	"github.com/arquivei/goduck/impl/implstream"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStream(t *testing.T) {
+	processor := implprocessor.New(nil)
+	stream := implstream.NewDefaultStream(0, 100)
+	defer func() {
+		stream.Close()
+	}()
+
+	w := runoncenegine.New(processor, 101, 100*time.Millisecond, stream)
+	err := w.Run(context.Background())
+	assert.NoError(t, err)
+
+	assert.Equal(t, 100, len(processor.Success))
+}
+
+func TestStreamNoTimeout(t *testing.T) {
+	processor := implprocessor.New(nil)
+	stream := implstream.NewDefaultStream(0, 100)
+
+	defer func() {
+		stream.Close()
+	}()
+
+	w := runoncenegine.New(processor, 15, 0, stream)
+	err := w.Run(context.Background())
+	assert.NoError(t, err)
+
+	assert.Equal(t, 15, len(processor.Success))
+}
+
+// TestStreamCancel asserts that the engine stops when context is close
+func TestStreamCancel(t *testing.T) {
+	wait := make(chan struct{})
+	done := make(chan struct{})
+	processor := implprocessor.New(func() error {
+		<-wait
+		return nil
+	})
+	stream := implstream.NewDefaultStream(0, 100)
+
+	defer func() {
+		stream.Close()
+	}()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	w := runoncenegine.New(processor, 10, 100*time.Millisecond, stream)
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+	cancelFn()
+	close(wait)
+	<-done
+}
+
+// TestStreamFatal asserts that the engine stops when the processor returns a
+// fatal error
+func TestStreamFatal(t *testing.T) {
+	expectedErr := errors.E("my error", errors.SeverityFatal)
+
+	processor := implprocessor.New(func() error {
+		return expectedErr
+	})
+
+	stream := implstream.NewDefaultStream(0, 100)
+
+	defer func() {
+		stream.Close()
+	}()
+
+	w := runoncenegine.New(processor, 10, 100*time.Millisecond, stream)
+	err := w.Run(context.Background())
+	assert.Equal(t, expectedErr, err)
+}

--- a/pipeline/builder.go
+++ b/pipeline/builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arquivei/foundationkit/gokitmiddlewares/trackingmiddleware"
 	"github.com/arquivei/goduck/engine/batchstreamengine"
 	"github.com/arquivei/goduck/engine/jobpoolengine"
+	"github.com/arquivei/goduck/engine/runoncenegine"
 	"github.com/arquivei/goduck/engine/streamengine"
 	"github.com/arquivei/goduck/gokithelper"
 	"github.com/go-kit/kit/endpoint"
@@ -38,6 +39,8 @@ func build(c pipelineBuilderOptions) (Pipeline, error) {
 	}
 
 	switch {
+	case shouldBuildWithRunOnceEngine(c):
+		err = buildWithRunOnceEngine(c, p)
 	case shouldBuildWithMessagePoolEngine(c) && shouldBuildWithSomeStreamEngine(c):
 		// sanity check
 		// This is already checked by checkPipelineBuilderOptions()
@@ -65,6 +68,10 @@ func shouldBuildWithMessagePoolEngine(c pipelineBuilderOptions) bool {
 
 func shouldBuildWithSomeStreamEngine(c pipelineBuilderOptions) bool {
 	return len(c.inputStreams) > 0
+}
+
+func shouldBuildWithRunOnceEngine(c pipelineBuilderOptions) bool {
+	return c.engineType == EngineTypeRunOnce
 }
 
 func buildWithBachStreamEngine(internalConfig pipelineBuilderOptions, pipe *pipeline) error {
@@ -141,6 +148,34 @@ func buildWithMessagePoolEngine(builderOpts pipelineBuilderOptions, pipe *pipeli
 		builderOpts.messagePool,
 		processor,
 		builderOpts.nPoolWorkers,
+	)
+	return nil
+}
+
+func buildWithRunOnceEngine(internalConfig pipelineBuilderOptions, pipe *pipeline) error {
+	processor, err := gokithelper.NewEndpointBatchProcessor(
+		internalConfig.endpoint,
+		internalConfig.batchDecoder,
+	)
+	if err != nil {
+		return err
+	}
+
+	if internalConfig.dlq.brokers != nil {
+		processor = dlqmiddleware.WrapBatch(
+			processor,
+			internalConfig.dlq.brokers,
+			internalConfig.dlq.topic,
+			internalConfig.dlq.username,
+			internalConfig.dlq.password,
+		)
+	}
+
+	pipe.engine = runoncenegine.New(
+		processor,
+		internalConfig.batchSize,
+		internalConfig.maxTimeout,
+		internalConfig.inputStreams[0],
 	)
 	return nil
 }

--- a/pipeline/builder_options.go
+++ b/pipeline/builder_options.go
@@ -14,6 +14,9 @@ type pipelineBuilderOptions struct {
 	// endpoint that executes the main business logic
 	endpoint endpoint.Endpoint
 
+	// engineType determines the type of engine to be used
+	engineType string
+
 	// GoDuck configuration:
 	//
 	// inputStreams are the message sources

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -7,11 +7,16 @@ import (
 	"github.com/arquivei/goduck/impl/implqueue/pubsubqueue"
 )
 
+const (
+	EngineTypeRunOnce = "run_once_engine"
+)
+
 // Config contains the parameters for a general purpose pipeline. This
 // should be set by the user that is running the pipeline.
 // This goes nicely with app.SetupConfig().
 type Config struct {
 	SystemName  string
+	EngineType  string
 	InputStream struct {
 		Provider string
 		Kafka    struct {

--- a/pipeline/pipeline_options.go
+++ b/pipeline/pipeline_options.go
@@ -33,6 +33,7 @@ func WithConfig(userConfig Config) Option {
 		withMessagePoolConfig(userConfig.MessagePool)(c)
 
 		c.middlewares = append(c.middlewares, getMiddlewares(userConfig)...)
+		c.engineType = userConfig.EngineType
 	}
 }
 


### PR DESCRIPTION
Adiciona RunOnceEngine, um engine simples que lê um batch de mensagens, processa e termina.

Essa é uma engine apropriada para testes que não podem ficar rodando indefinidamente.