### PR TITLE
Implement config for the backoff middleware

### DIFF
--- a/pipeline/builder.go
+++ b/pipeline/builder.go
@@ -186,13 +186,13 @@ func getMiddlewares(config Config) []endpoint.Middleware {
 		Wait:          true,
 		ErrorSeverity: errors.SeverityFatal,
 	}
-	retryConfig := backoffmiddleware.NewDefaultConfig()
+	retryBackoffConfig := withBackoffmiddlewareConfig(config)
 	loggingConfig := loggingmiddleware.NewDefaultConfig(config.SystemName)
 
 	e := []endpoint.Middleware{
 		trackingmiddleware.New(),
 		gokitmiddlewares.Must(timeoutmiddleware.New(timeoutConfig)),
-		backoffmiddleware.New(retryConfig),
+		backoffmiddleware.New(retryBackoffConfig),
 		loggingmiddleware.MustNew(loggingConfig),
 	}
 	if config.StaleAfter > 0 {
@@ -201,5 +201,23 @@ func getMiddlewares(config Config) []endpoint.Middleware {
 		e = append(e, stalemiddleware.New(c))
 		log.Warn().Msgf("[goduck][pipeline] Stale middleware is active. The system will be set to unhealthy if no message is received in %s.", config.StaleAfter.String())
 	}
+
+	if config.InputStream.DLQKafkaTopic != "" && config.Backoffmiddleware.MaxRetries == backoffmiddleware.MaxRetriesInfinite {
+		log.Warn().Msgf("[goduck][pipeline] DLQ is active but max retries is set as infinite. This may cause a infinite loop if the returned service error with wrigth severity was not SeverityInput type.")
+	}
+
 	return e
+}
+
+// withBackoffmiddlewareConfig returns a backoffmiddleware.Config with the values
+// from the Config struct. If the values are not set, the default values are used.
+// It will be used to create the backoffmiddleware.
+func withBackoffmiddlewareConfig(config Config) backoffmiddleware.Config {
+	return backoffmiddleware.Config{
+		InitialDelay: config.Backoffmiddleware.InitialDelay,
+		MaxDelay:     config.Backoffmiddleware.MaxDelay,
+		Spread:       config.Backoffmiddleware.Spread,
+		Factor:       config.Backoffmiddleware.Factor,
+		MaxRetries:   config.Backoffmiddleware.MaxRetries,
+	}
 }

--- a/pipeline/builder.go
+++ b/pipeline/builder.go
@@ -186,7 +186,7 @@ func getMiddlewares(config Config) []endpoint.Middleware {
 		Wait:          true,
 		ErrorSeverity: errors.SeverityFatal,
 	}
-	retryBackoffConfig := withBackoffmiddlewareConfig(config)
+	retryBackoffConfig := newBackoffmiddlewareConfig(config)
 	loggingConfig := loggingmiddleware.NewDefaultConfig(config.SystemName)
 
 	e := []endpoint.Middleware{
@@ -202,17 +202,13 @@ func getMiddlewares(config Config) []endpoint.Middleware {
 		log.Warn().Msgf("[goduck][pipeline] Stale middleware is active. The system will be set to unhealthy if no message is received in %s.", config.StaleAfter.String())
 	}
 
-	if config.InputStream.DLQKafkaTopic != "" && config.Backoffmiddleware.MaxRetries == backoffmiddleware.MaxRetriesInfinite {
-		log.Warn().Msgf("[goduck][pipeline] DLQ is active but max retries is set as infinite. This may cause a infinite loop if the returned service error with wrigth severity was not SeverityInput type.")
-	}
-
 	return e
 }
 
-// withBackoffmiddlewareConfig returns a backoffmiddleware.Config with the values
+// newBackoffmiddlewareConfig returns a backoffmiddleware.Config with the values
 // from the Config struct. If the values are not set, the default values are used.
 // It will be used to create the backoffmiddleware.
-func withBackoffmiddlewareConfig(config Config) backoffmiddleware.Config {
+func newBackoffmiddlewareConfig(config Config) backoffmiddleware.Config {
 	return backoffmiddleware.Config{
 		InitialDelay: config.Backoffmiddleware.InitialDelay,
 		MaxDelay:     config.Backoffmiddleware.MaxDelay,

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -39,6 +39,13 @@ type Config struct {
 		Username string
 		Password string `secret:"true"`
 	}
+	Backoffmiddleware struct {
+		InitialDelay time.Duration `default:"200ms"`
+		MaxDelay     time.Duration `default:"10s"`
+		Spread       float64       `default:"0.2"`
+		Factor       float64       `default:"1.5"`
+		MaxRetries   int           `default:"-1"`
+	}
 }
 
 // MessagePoolConfig contains parameters for configuring a Message

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -62,5 +62,10 @@ func checkConfig(config *Config) error {
 	if config.SystemName == "" {
 		return errors.E(op, ErrSystemNameEmpty)
 	}
+
+	if config.InputStream.DLQKafkaTopic != "" && config.Backoffmiddleware.MaxRetries == -1 {
+		return errors.E(op, ErrInfiniteBehavior)
+	}
+
 	return nil
 }

--- a/pipeline/errors.go
+++ b/pipeline/errors.go
@@ -24,4 +24,7 @@ var (
 	ErrSinkEncoderNil = errors.New("sink encoder is nil")
 	// ErrSystemNameEmpty is an error returned when the system name is empty.
 	ErrSystemNameEmpty = errors.New("system name is empty")
+	// ErrInfiniteBehavior is an error returned when the DLQ is active but max retries is set as infinite.
+	// This may cause an infinite loop if the returned service error with wright severity was not SeverityInput type.
+	ErrInfiniteBehavior = errors.New("DLQ is active but max retries is set as infinite")
 )


### PR DESCRIPTION
Issue:

During an incident in which we experienced a message bottleneck that was being indefinitely reattempted, we realized that the backoff middleware was instantiating the default configurations of the retrier and not allowing these configurations to be passed as parameters.

Solution:

Add to the configuration structure of the pipelines configurations for the backoff middleware's retrier. To maintain backward compatibility, if these configurations are not defined, default configurations will be used. Additionally, if a Dead Letter Queue (DLQ) topic is defined in the config but the number of retries is set to infinite, a warning log indicating the risk of an infinite loop will be emitted during resource instantiation.