### PR TITLE
Adds configs for custom processors

### DIFF
--- a/pipeline/builder_options.go
+++ b/pipeline/builder_options.go
@@ -4,9 +4,10 @@ import (
 	"time"
 
 	"github.com/arquivei/foundationkit/errors"
-	"github.com/arquivei/goduck"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/rs/zerolog/log"
+
+	"github.com/arquivei/goduck"
 )
 
 // pipelineBuilderOptions is the configuration of a pipeline.
@@ -58,6 +59,12 @@ type pipelineBuilderOptions struct {
 	}
 
 	middlewares []endpoint.Middleware
+
+	// processor is a processor that overrides the default one
+	processor goduck.Processor
+
+	// batchProcessor is a batchProcessor that overrides the default one
+	batchProcessor goduck.BatchProcessor
 }
 
 func checkPipelineBuilderOptions(c pipelineBuilderOptions) error {

--- a/pipeline/pipeline_options.go
+++ b/pipeline/pipeline_options.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/kit/endpoint"
+
 	"github.com/arquivei/goduck"
 	"github.com/arquivei/goduck/impl/implqueue/pubsubqueue"
-	"github.com/go-kit/kit/endpoint"
 )
 
 // Option applies an option to the Config struct
@@ -48,6 +49,20 @@ func WithEndpoint(e endpoint.Endpoint) Option {
 func WithInputStreams(s ...goduck.Stream) Option {
 	return func(c *pipelineBuilderOptions) {
 		c.inputStreams = s
+	}
+}
+
+// WithProcessor adds a processor to the config struct
+func WithProcessor(p goduck.Processor) Option {
+	return func(c *pipelineBuilderOptions) {
+		c.processor = p
+	}
+}
+
+// WithBatchProcessor adds a batchProcessor to the config struct
+func WithBatchProcessor(p goduck.BatchProcessor) Option {
+	return func(c *pipelineBuilderOptions) {
+		c.batchProcessor = p
 	}
 }
 


### PR DESCRIPTION
There is an interface for custom processors, but no way to inject them into the build process. This commit adds new internal options alongside public methods for injections of a custom processor. Also disables the building of default processors when a custom one is given.